### PR TITLE
Move admonition processing after conversion to avoid incorrect output

### DIFF
--- a/convert.sh
+++ b/convert.sh
@@ -10,8 +10,8 @@ cp -r ./i18n/zh/docusaurus-plugin-content-docs/current ./kramdown_md_to_asciidoc
 
 find ./kramdown_md_to_asciidoc -type f \( -name "*.md" -o -name "*.mdx" \) -exec sh -c 'echo Processing Head tag in file $1 & head_tag.sh "$1" "antora"' _ {} \;
 find ./kramdown_md_to_asciidoc -type f -name "*.md" -exec sh -c 'echo Replacing Collapsible blocks in file $1 & collapsible_block.sh "$1" ' _ {} \;
-find ./kramdown_md_to_asciidoc -type f -name "*.md" -exec sh -c 'echo Replacing Admonitions in file $1 & admon.sh "$1" ' _ {} \;
-find ./kramdown_md_to_asciidoc -type f -name "*.md" -exec sh -c 'echo Processing file $1 & kramdoc -o "${1%.md}.adoc" "$1"' _ {} \;
+find ./kramdown_md_to_asciidoc -type f -name "*.md" -exec sh -c 'echo Converting file $1 & kramdoc -o "${1%.md}.adoc" "$1"' _ {} \;
+find ./kramdown_md_to_asciidoc -type f -name "*.adoc" -exec sh -c 'echo Replacing Admonitions in file $1 & admon.sh "$1" ' _ {} \;
 find ./kramdown_md_to_asciidoc -type f -name "*.adoc" -exec sh -c 'echo Replacing cross reference links in file "$1" && sed -i "s|\\(link:[^ ]*\\)\\.md|\\1.adoc|g" "$1"' _ {} \;
 
 rm ./kramdown_md_to_asciidoc/**/*.md


### PR DESCRIPTION
Replacing admonitions before conversion leads to the converter trying to still process them and produces undesired results (prepends a `=`) for simple Docusaurus admonitions. 

E.g. starting with a simple Docusaurus admonition:

```
:::note

something

:::
```

Running admon.sh, it becomes this correct AsciiDoc admonition

```
[NOTE]
====

something

====
```

But then the converter turns it into:

```
= [NOTE]

something

====

```