### PR TITLE
Added nav.py to convert Docusaurus sidebars.js to Antora nav file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,14 @@ RUN apt-get update && \
 RUN gem install kramdown-asciidoc
 
 # Copy the script into the container
-COPY convert.sh admon.sh collapsible_block.sh head_tag.sh tabs.sh /usr/local/bin/
+COPY convert.sh admon.sh collapsible_block.sh head_tag.sh nav.py tabs.sh /usr/local/bin/
 
 # Set the script as executable
 RUN chmod +x /usr/local/bin/convert.sh \
              /usr/local/bin/admon.sh \
              /usr/local/bin/collapsible_block.sh \
              /usr/local/bin/head_tag.sh \
+             /usr/local/bin/nav.py \
              /usr/local/bin/tabs.sh
 
 # Set the working directory

--- a/convert.sh
+++ b/convert.sh
@@ -5,7 +5,7 @@ shopt -s globstar
 rm -rf ./kramdown_md_to_asciidoc && \
 mkdir -p ./kramdown_md_to_asciidoc && \
 mkdir -p ./kramdown_md_to_asciidoc/i18n/zh/docusaurus-plugin-content-docs && \
-cp -r ./docs ./shared-files ./kramdown_md_to_asciidoc && \
+cp -r ./docs ./shared-files ./sidebars.js ./kramdown_md_to_asciidoc && \
 cp -r ./i18n/zh/docusaurus-plugin-content-docs/current ./kramdown_md_to_asciidoc/i18n/zh/docusaurus-plugin-content-docs
 
 find ./kramdown_md_to_asciidoc -type f \( -name "*.md" -o -name "*.mdx" \) -exec sh -c 'echo Processing Head tag in file $1 & head_tag.sh "$1" "antora"' _ {} \;
@@ -14,5 +14,7 @@ find ./kramdown_md_to_asciidoc -type f -name "*.md" -exec sh -c 'echo Replacing 
 find ./kramdown_md_to_asciidoc -type f -name "*.md" -exec sh -c 'echo Converting file $1 & kramdoc -o "${1%.md}.adoc" "$1"' _ {} \;
 find ./kramdown_md_to_asciidoc -type f -name "*.adoc" -exec sh -c 'echo Replacing Admonitions in file $1 & admon.sh "$1" ' _ {} \;
 find ./kramdown_md_to_asciidoc -type f -name "*.adoc" -exec sh -c 'echo Replacing cross reference links in file "$1" && sed -i "s|\\(link:[^ ]*\\)\\.md|\\1.adoc|g" "$1"' _ {} \;
+find ./kramdown_md_to_asciidoc -type f -name "*.js" -exec sh -c 'echo Converting sidebar file $1 & python3 /usr/local/bin/nav.py "$1" ' _ {} \;
 
 rm ./kramdown_md_to_asciidoc/**/*.md
+rm ./kramdown_md_to_asciidoc/**/sidebars*.js

--- a/convert.sh
+++ b/convert.sh
@@ -14,7 +14,8 @@ find ./kramdown_md_to_asciidoc -type f -name "*.md" -exec sh -c 'echo Replacing 
 find ./kramdown_md_to_asciidoc -type f -name "*.md" -exec sh -c 'echo Converting file $1 & kramdoc -o "${1%.md}.adoc" "$1"' _ {} \;
 find ./kramdown_md_to_asciidoc -type f -name "*.adoc" -exec sh -c 'echo Replacing Admonitions in file $1 & admon.sh "$1" ' _ {} \;
 find ./kramdown_md_to_asciidoc -type f -name "*.adoc" -exec sh -c 'echo Replacing cross reference links in file "$1" && sed -i "s|\\(link:[^ ]*\\)\\.md|\\1.adoc|g" "$1"' _ {} \;
-find ./kramdown_md_to_asciidoc -type f -name "*.js" -exec sh -c 'echo Converting sidebar file $1 & python3 /usr/local/bin/nav.py "$1" ' _ {} \;
+find ./kramdown_md_to_asciidoc -type f \( -name "*sidebars.js" -o -name "*sidebars.json" \) -exec sh -c 'echo Converting sidebar file "$1" && python3 /usr/local/bin/nav.py "$1"' _ {} \;
 
 rm ./kramdown_md_to_asciidoc/**/*.md
 rm ./kramdown_md_to_asciidoc/**/sidebars*.js
+rm ./kramdown_md_to_asciidoc/**/*sidebars.json

--- a/nav.py
+++ b/nav.py
@@ -1,0 +1,57 @@
+import json
+import re
+import sys
+import os
+
+def extract_json_from_js(js_content):
+    no_comments = re.sub(r'^\s*//.*\n?', '', js_content, flags=re.MULTILINE)
+    json_match = re.search(r'const sidebars = (\{.*\n(?:.|\n)*?\})', no_comments, re.DOTALL)
+    
+    if json_match:
+        json_str = re.sub(r'(\w+):', r'"\1":', json_match.group(1)).replace('\n', '').replace("'", '"')
+        json_str = re.sub(r',\s*([\]}])', r'\1', json_str)
+        return json.loads(json_str)
+    return None
+
+def format_item(prefix, label, link_id=None):
+    if link_id:
+        return f"{prefix}xref:{link_id}.adoc[{label}]"
+    return f"{prefix}{label}"
+
+def process_items(items, depth=1):
+    result = []
+    prefix = '*' * depth + ' '
+    
+    for item in items:
+        if isinstance(item, str):
+            result.append(format_item(prefix, item.split('/')[-1].replace('-', ' ').title(), item))
+        elif isinstance(item, dict):
+            label = item.get('label', 'Category')
+            if 'link' in item:
+                result.append(format_item(prefix, label, item['link']['id']))
+            if 'items' in item:
+                if 'link' not in item:
+                    result.append(format_item(prefix, label))
+                result.extend(process_items(item['items'], depth + 1))
+    return result
+
+def main():
+    if len(sys.argv) != 2:
+        print('Usage: python nav.py sidebar.js')
+        sys.exit(1)
+    
+    sidebar_path = sys.argv[1]
+    nav_path = os.path.splitext(sidebar_path)[0] + '.adoc'
+    
+    with open(sidebar_path, 'r', encoding='utf-8') as f:
+        sidebar = extract_json_from_js(f.read())
+    
+    nav_content = []
+    for key, sections in sidebar.items():
+        nav_content.extend(process_items(sections))
+    
+    with open(nav_path, 'w') as f:
+        f.write("\n".join(nav_content))
+
+if __name__ == '__main__':
+    main()

--- a/nav.py
+++ b/nav.py
@@ -13,42 +13,69 @@ def extract_json_from_js(js_content):
         return json.loads(json_str)
     return None
 
-def format_item(prefix, label, link_id=None):
+def does_doc_file_contain_title_slug(file_path):
+    if os.path.exists(file_path):
+        with open(file_path, 'r') as file:
+            content = file.read()
+        pattern = re.compile(r'^title:\s+.+', re.MULTILINE)
+        match = pattern.search(content)
+        if match:
+            return True
+        else:
+            return False
+    else:
+        return False
+    
+
+def format_item(base_path, prefix, label, link_id=None):
     if link_id:
-        return f"{prefix}xref:{link_id}.adoc[{label}]"
+        root, ext = os.path.splitext(link_id)
+        file_path = base_path + "/" + root + ".md"
+        if(does_doc_file_contain_title_slug(file_path)):
+            return f"{prefix}xref:{link_id}.adoc[]"
+        else:
+            return f"{prefix}xref:{link_id}.adoc[{label}]"
     return f"{prefix}{label}"
 
-def process_items(items, depth=1):
+def process_items(base_path, items, depth=1):
     result = []
     prefix = '*' * depth + ' '
     
     for item in items:
         if isinstance(item, str):
-            result.append(format_item(prefix, item.split('/')[-1].replace('-', ' ').title(), item))
+            result.append(format_item(base_path, prefix, item.split('/')[-1].replace('-', ' ').title(), item))
         elif isinstance(item, dict):
             label = item.get('label', 'Category')
             if 'link' in item:
-                result.append(format_item(prefix, label, item['link']['id']))
+                result.append(format_item(base_path, prefix, label, item['link']['id']))
             if 'items' in item:
                 if 'link' not in item:
-                    result.append(format_item(prefix, label))
-                result.extend(process_items(item['items'], depth + 1))
+                    result.append(format_item(base_path, prefix, label))
+                result.extend(process_items(base_path, item['items'], depth + 1))
     return result
 
 def main():
     if len(sys.argv) != 2:
         print('Usage: python nav.py sidebar.js')
         sys.exit(1)
-    
+        
+    if "versioned_" in sys.argv[1]:
+        base_path = "./kramdown_md_to_asciidoc/versioned_docs/" + os.path.splitext(os.path.basename(sys.argv[1]))[0]
+    else:
+        base_path = "./kramdown_md_to_asciidoc/docs"
+        
     sidebar_path = sys.argv[1]
     nav_path = os.path.splitext(sidebar_path)[0] + '.adoc'
     
     with open(sidebar_path, 'r', encoding='utf-8') as f:
-        sidebar = extract_json_from_js(f.read())
+        if "versioned_" in sys.argv[1]:
+            sidebar = json.loads(f.read())
+        else:
+            sidebar = extract_json_from_js(f.read())
     
     nav_content = []
     for key, sections in sidebar.items():
-        nav_content.extend(process_items(sections))
+        nav_content.extend(process_items(base_path, sections))
     
     with open(nav_path, 'w') as f:
         f.write("\n".join(nav_content))


### PR DESCRIPTION
Added nav.py that looks for all sidebars*.js files in a Docusaurus project and converts them to equivalent Antora nav file syntax.

Note: 

- Calling the .py file directly from the conversion script as escaping characters within a python file that's called within a bash script got more challenging.

- The nav titles are extracted only from the sidebars.js file. If title is set in the actual doc (.md) file in the header using `title:` slug, the script still uses the title provided in the sidebars.js.