### PR TITLE
Move tab processing after conversion

### DIFF
--- a/convert.sh
+++ b/convert.sh
@@ -10,8 +10,8 @@ cp -r ./i18n/zh/docusaurus-plugin-content-docs/current ./kramdown_md_to_asciidoc
 
 find ./kramdown_md_to_asciidoc -type f \( -name "*.md" -o -name "*.mdx" \) -exec sh -c 'echo Processing Head tag in file $1 & head_tag.sh "$1" "antora"' _ {} \;
 find ./kramdown_md_to_asciidoc -type f -name "*.md" -exec sh -c 'echo Replacing Collapsible blocks in file $1 & collapsible_block.sh "$1" ' _ {} \;
-find ./kramdown_md_to_asciidoc -type f -name "*.md" -exec sh -c 'echo Replacing Tabs in file $1 & tabs.sh "$1" ' _ {} \;
 find ./kramdown_md_to_asciidoc -type f -name "*.md" -exec sh -c 'echo Converting file $1 & kramdoc -o "${1%.md}.adoc" "$1"' _ {} \;
+find ./kramdown_md_to_asciidoc -type f -name "*.adoc" -exec sh -c 'echo Replacing Tabs in file $1 & tabs.sh "$1" ' _ {} \;
 find ./kramdown_md_to_asciidoc -type f -name "*.adoc" -exec sh -c 'echo Replacing Admonitions in file $1 & admon.sh "$1" ' _ {} \;
 find ./kramdown_md_to_asciidoc -type f -name "*.adoc" -exec sh -c 'echo Replacing cross reference links in file "$1" && sed -i "s|\\(link:[^ ]*\\)\\.md|\\1.adoc|g" "$1"' _ {} \;
 

--- a/tabs-test.md
+++ b/tabs-test.md
@@ -1,0 +1,81 @@
+## 1. Tabs
+
+<Tabs>
+  <TabItem value="apple">
+    This is an apple.
+  </TabItem>
+  <TabItem value="orange">
+    This is an orange.
+  </TabItem>
+  <TabItem value="banana">
+    This is a banana.
+  </TabItem>
+</Tabs>
+
+## 2. Tabs with default
+
+<Tabs>
+  <TabItem value="apple">
+    This is an apple.
+  </TabItem>
+  <TabItem value="orange" default>
+    This is an orange.
+  </TabItem>
+  <TabItem value="banana">
+    This is a banana.
+  </TabItem>
+</Tabs>
+
+## 3. Tabs with labels
+
+<Tabs>
+  <TabItem value="apple" label="Apple" default>
+    This is an apple 🍎
+  </TabItem>
+  <TabItem value="orange" label="Orange">
+    This is an orange 🍊
+  </TabItem>
+  <TabItem value="banana" label="Banana">
+    This is a banana 🍌
+  </TabItem>
+</Tabs>
+
+## 4. Tabs with syncing
+
+<Tabs groupId="operating-systems">
+  <TabItem value="win" label="Windows">Use Ctrl + C to copy.</TabItem>
+  <TabItem value="mac" label="macOS">Use Command + C to copy.</TabItem>
+</Tabs>
+
+<Tabs groupId="operating-systems">
+  <TabItem value="win" label="Windows">Use Ctrl + V to paste.</TabItem>
+  <TabItem value="mac" label="macOS">Use Command + V to paste.</TabItem>
+</Tabs>
+
+## 5. Tabs nested in another element
+
+1. Some text.
+
+1. More text.
+    <Tabs>
+    <TabItem value="Add a new persistent volume">
+
+      1. Enter a **Name** for the volume claim.
+      1. Select a volume claim **Source**:
+          - If you select **Use a Storage Class to provision a new persistent volume**, select a storage class and enter a **Capacity**.
+          - If you select **Use an existing persistent volume**, choose a **Persistent Volume** from the drop-down.
+      1. From the **Customize** section, choose the read/write access for the volume.
+      1. Click **Define**.
+
+    </TabItem>
+    <TabItem value="Use an existing persistent volume">
+
+      1. Enter a **Name** for the volume claim.
+      1. Choose a **Persistent Volume Claim** from the dropdown.
+      1. From the **Customize** section, choose the read/write access for the volume.
+      1. Click **Define**.
+
+    </TabItem>
+    </Tabs>
+
+1. Final text.

--- a/tabs-test.md
+++ b/tabs-test.md
@@ -43,13 +43,21 @@
 ## 4. Tabs with syncing
 
 <Tabs groupId="operating-systems">
-  <TabItem value="win" label="Windows">Use Ctrl + C to copy.</TabItem>
-  <TabItem value="mac" label="macOS">Use Command + C to copy.</TabItem>
+  <TabItem value="win" label="Windows">
+    Use Ctrl + C to copy.
+  </TabItem>
+  <TabItem value="mac" label="macOS">
+    Use Command + C to copy.
+  </TabItem>
 </Tabs>
 
 <Tabs groupId="operating-systems">
-  <TabItem value="win" label="Windows">Use Ctrl + V to paste.</TabItem>
-  <TabItem value="mac" label="macOS">Use Command + V to paste.</TabItem>
+  <TabItem value="win" label="Windows">
+    Use Ctrl + V to paste.
+  </TabItem>
+  <TabItem value="mac" label="macOS">
+    Use Command + V to paste.
+  </TabItem>
 </Tabs>
 
 ## 5. Tabs nested in another element
@@ -66,14 +74,32 @@
           - If you select **Use an existing persistent volume**, choose a **Persistent Volume** from the drop-down.
       1. From the **Customize** section, choose the read/write access for the volume.
       1. Click **Define**.
+      1. Modify `somevalue` afterwards.
 
     </TabItem>
     <TabItem value="Use an existing persistent volume">
 
+      :::note
+
+      TAKE NOTE
+
+      ```
+
       1. Enter a **Name** for the volume claim.
       1. Choose a **Persistent Volume Claim** from the dropdown.
+      1. Add this YAML:
+        ```yaml
+        int: 123
+          string: 'abc' 
+        ```
       1. From the **Customize** section, choose the read/write access for the volume.
       1. Click **Define**.
+
+      Then run the following command:
+
+      ```shell
+      kubectl do something
+      ```
 
     </TabItem>
     </Tabs>

--- a/tabs.sh
+++ b/tabs.sh
@@ -10,11 +10,14 @@ import sys
 def tabs_ds2ad(adt):
     # Convert tabs from Docusaurus to Asciidoctor
     replacements = [
-        (r'<Tabs>', '[tabs]\n====\n'),
-        (r'<Tabs groupId=\"([^\"]+)\">', r'[tabs,sync-group-id=\\1]\n====\n'),
-        (r'<TabItem value=\"([^\"]+)\">', r'Tab \\1::'),
-        (r'</TabItem>\n', ''),
-        (r'</Tabs>', '====')
+        (r'(\+)*<Tabs>(\+)*', '\n\n[tabs]\n===='),
+        (r'(\+)*<Tabs groupId=\"([^\"]+)\">(\+)*', r'\n\n[tabs,sync-group-id=\\2]\n===='),
+        (r'====(\+)*<TabItem value=\"([^\"]+)\" label=\"([^\"]+)\"( default=\"\")?>(\+)*', r'====\nTab \\3::\n+\n'),
+        (r'====(\+)*<TabItem value=\"([^\"]+)\"( default=\"\")?>(\+)*', r'====\nTab \\2::\n+\n'),
+        (r'(\+)*<TabItem value=\"([^\"]+)\" label=\"([^\"]+)\"( default=\"\")?>(\+)*', r'\n\nTab \\3::\n+\n'),
+        (r'(\+)*<TabItem value=\"([^\"]+)\"( default=\"\")?>(\+)*', r'\n\nTab \\2::\n+\n'),
+        (r'(\+)*</TabItem>(\+)*', ''),
+        (r'(\+)*</Tabs>(\+)*', '\n====')
     ]
 
     for pattern, replacement in replacements:


### PR DESCRIPTION
Tabs aren't recognized by Kramdoc since it's not a standard Asciidoc element so it still tries to convert the (correct) tab syntax. This PR moves the tab processing to after the conversion and updates the match patterns to account for the Kramdoc changes.

Went with this approach as Approach 2 requires a lot more work on script.

Notes:
1. Added a test input file for testing purposes.
2. Parse other Tab tag attributes (label, default).
3. If other AsciiDoc elements are nested inside a Tab, that content will need to be converted.

### Approach 2 (extend current approach)

1. Process tabs (add bits from Note 2).
2. Convert md to adoc (this modifies/undoes some of the changes done in the previous step)
3. Process tabs again.

With Approach 2:
- Note 3 happens for some cases (e.g. Tab 2 of last section of test file) but not for others (Tab 1 of last section of test file).
- Identation is preserved, but indentation isn't applicable to asciidoctor-tabs. 
    - The number of `*`, `.` on lists will need to be processed as well.



